### PR TITLE
fix get-params; fix default script URI in params

### DIFF
--- a/parameters.json
+++ b/parameters.json
@@ -18,7 +18,7 @@
             "value": ""
         },
         "ScriptsRepositoryUri": {
-            "value": "https://storeus2avdalerts.blob.core.windows.net/deployment/"
+            "value": "https://github.com/JCoreMS/AVDAlerts/blob/main/scripts/"
         },
         "SessionHostsResourceGroupIds": {
             "value": [


### PR DESCRIPTION
Minor updates to Get-Parameters script 
- Host Pool Resource IDs not populating if only single found
- Subscription ID variable not being populated correctly

Updated Script Repository URI for Parameters default
- Personal Blob storage used during testing was still in get-parameters script and default parameters.json used by buttons